### PR TITLE
Fix: `scrollToItem` method not working with dynamic size

### DIFF
--- a/.changeset/warm-waves-brake.md
+++ b/.changeset/warm-waves-brake.md
@@ -1,0 +1,5 @@
+---
+"react-cool-virtual": patch
+---
+
+fix: `scrollToItem` method not working with dynamic size

--- a/app/src/App/index.tsx
+++ b/app/src/App/index.tsx
@@ -20,12 +20,13 @@ const mockData = getMockData(50);
 
 export default (): JSX.Element => {
   const [sz, setSz] = useState(50);
-  const { outerRef, innerRef, items } = useVirtual<
+  const { outerRef, innerRef, items, scrollTo, scrollToItem } = useVirtual<
     HTMLDivElement,
     HTMLDivElement
   >({
     itemCount: mockData.length,
     // itemSize: 100,
+    // overscanCount: 0,
   });
 
   return (
@@ -49,9 +50,13 @@ export default (): JSX.Element => {
       </div>
       <button
         type="button"
-        onClick={() => setSz((prev) => (prev === 50 ? 200 : 50))}
+        onClick={() =>
+          scrollToItem({ index: 500, smooth: false }, () =>
+            console.log("LOG ===> Done")
+          )
+        }
       >
-        Resize
+        Scroll To...
       </button>
     </div>
   );

--- a/app/src/App/styles.module.scss
+++ b/app/src/App/styles.module.scss
@@ -11,7 +11,7 @@ body {
 .outer {
   margin: 0 auto;
   width: 300px;
-  height: 500px;
+  height: 300px;
   border: 1px solid #000;
   margin-bottom: 1rem;
   overflow: auto;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,7 +84,6 @@ export interface ScrollToItemOptions {
   index: number;
   align?: Align;
   smooth?: boolean;
-  autoCorrect?: boolean;
 }
 
 export interface ScrollToItem {

--- a/src/types/react-cool-virtual.d.ts
+++ b/src/types/react-cool-virtual.d.ts
@@ -92,7 +92,6 @@ declare module "react-cool-virtual" {
     index: number;
     align?: "auto" | "start" | "center" | "end";
     smooth?: boolean;
-    autoCorrect?: boolean;
   }
 
   export interface ScrollToItem {


### PR DESCRIPTION
- Fix: `scrollToItem` method not working with dynamic size