### PR TITLE
fix: the callback of `scrollToItem` is called twice

### DIFF
--- a/.changeset/stale-glasses-wonder.md
+++ b/.changeset/stale-glasses-wonder.md
@@ -1,0 +1,5 @@
+---
+"react-cool-virtual": patch
+---
+
+fix: the callback of `scrollToItem` is called twice

--- a/src/useVirtual.ts
+++ b/src/useVirtual.ts
@@ -232,11 +232,14 @@ export default <
 
       if (
         hasDynamicSizeRef.current &&
+        align === Align.auto &&
         scrollOffset <= start &&
         scrollOffset + outerSize >= end &&
         cb
-      )
+      ) {
         cb();
+        return;
+      }
 
       const endPos = start - outerSize + size;
 


### PR DESCRIPTION
- fix: the callback of `scrollToItem` is called twice