### PR TITLE
fix: pass correct args to `scrollToItem` method

### DIFF
--- a/.changeset/grumpy-fans-approve.md
+++ b/.changeset/grumpy-fans-approve.md
@@ -1,0 +1,5 @@
+---
+"react-cool-virtual": patch
+---
+
+fix: pass correct args to `scrollToItem` method

--- a/src/useVirtual.ts
+++ b/src/useVirtual.ts
@@ -268,7 +268,7 @@ export default <
           correctScrollCountRef.current <= MAX_CORRECT_SCROLL_COUNT &&
           (scrollOffset >= start || scrollOffset + outerSize <= end)
         ) {
-          setTimeout(() => scrollToItem(index, cb));
+          setTimeout(() => scrollToItem(val, cb));
           correctScrollCountRef.current += 1;
         } else {
           if (cb) cb();


### PR DESCRIPTION
- fix: pass correct args to `scrollToItem` method