### PR TITLE
fix: wrong the scroll position of `scrollToItem` when working with dynamic size

### DIFF
--- a/.changeset/chilly-plums-thank.md
+++ b/.changeset/chilly-plums-thank.md
@@ -1,0 +1,5 @@
+---
+"react-cool-virtual": patch
+---
+
+fix: wrong the scroll position of `scrollToItem` when working with dynamic size


### PR DESCRIPTION
- fix: wrong the scroll position of `scrollToItem` when working with dynamic size