### PR TITLE
fix: the callback of `scrollTo` not called when scroll to the same position

### DIFF
--- a/.changeset/angry-moons-pump.md
+++ b/.changeset/angry-moons-pump.md
@@ -1,0 +1,5 @@
+---
+"react-cool-virtual": patch
+---
+
+fix: the callback of `scrollTo` not called when scroll to the same position

--- a/src/useVirtual.ts
+++ b/src/useVirtual.ts
@@ -179,7 +179,10 @@ export default <
         ? { offset: val }
         : val;
 
-      if (!isNumber(offset) || offset === prevOffset) return;
+      if (!isNumber(offset) || offset === prevOffset) {
+        if (cb) cb();
+        return;
+      }
 
       userScrollRef.current = false;
 


### PR DESCRIPTION
- fix: the callback of `scrollTo` not called when scroll to the same position