### PR TITLE
refactor(types): use `RefCallback` as the type of `measureRef`

### DIFF
--- a/.changeset/forty-readers-unite.md
+++ b/.changeset/forty-readers-unite.md
@@ -1,0 +1,5 @@
+---
+"react-cool-virtual": patch
+---
+
+refactor(types): use `RefCallback` as the type of `measureRef`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from "react";
+import { MutableRefObject, RefCallback } from "react";
 
 // Internal
 export interface Measure {
@@ -55,7 +55,7 @@ export interface Item {
   readonly size: number;
   readonly width: number;
   readonly isScrolling?: boolean;
-  measureRef: (el: HTMLElement | null) => void;
+  measureRef: RefCallback<HTMLElement>;
 }
 
 export interface ScrollToOptions {

--- a/src/types/react-cool-virtual.d.ts
+++ b/src/types/react-cool-virtual.d.ts
@@ -1,5 +1,5 @@
 declare module "react-cool-virtual" {
-  import { MutableRefObject } from "react";
+  import { MutableRefObject, RefCallback } from "react";
 
   export interface ItemSizeFunction {
     (index: number, width: number): number;
@@ -56,9 +56,7 @@ declare module "react-cool-virtual" {
     (event: OnResizeEvent): void;
   }
 
-  export interface MeasureRef {
-    (el: HTMLElement | null): void;
-  }
+  export type MeasureRef = RefCallback<HTMLElement>;
 
   export interface Item {
     readonly index: number;


### PR DESCRIPTION
- refactor(types): use `RefCallback` as the type of `measureRef`