### PR TITLE
Feat: use `startItem` instead `startItemIndex` for pre-pending items

### DIFF
--- a/.changeset/nine-tigers-tell.md
+++ b/.changeset/nine-tigers-tell.md
@@ -1,0 +1,5 @@
+---
+"react-cool-virtual": minor
+---
+
+feat: use `startItem` instead `startItemIndex` for pre-pending items

--- a/README.md
+++ b/README.md
@@ -612,12 +612,12 @@ const fetchData = async (postId, setComments) => {
 
 const List = () => {
   const [comments, setComments] = useState([]);
-  const { outerRef, innerRef, items, startItemIndex } = useVirtual({
+  const { outerRef, innerRef, items, startItem } = useVirtual({
     // Provide the number of comments
     itemCount: comments.length,
-    onScroll: ({ scrollOffset }) => {
+    onScroll: ({ scrollForward, scrollOffset }) => {
       // Tweak the threshold of data fetching that you want
-      if (scrollOffset < 50 && shouldFetchData) {
+      if (!scrollForward && scrollOffset < 50 && shouldFetchData) {
         fetchData(--postId, setComments);
         shouldFetchData = false;
       }
@@ -626,15 +626,15 @@ const List = () => {
 
   useEffect(() => fetchData(postId, setComments), []);
 
-  // Execute the `startItemIndex` through `useLayoutEffect` before the browser to paint
+  // Execute the `startItem` through `useLayoutEffect` before the browser to paint
   // See https://reactjs.org/docs/hooks-reference.html#uselayouteffect to learn more
   useLayoutEffect(() => {
     // After the list updated, maintain the previous scroll position for the user
-    startItemIndex(BATCH_COMMENTS + 1, () => {
+    startItem(BATCH_COMMENTS, () => {
       // After the scroll position updated, re-allow data fetching
       if (comments.length < TOTAL_COMMENTS) shouldFetchData = true;
     });
-  }, [comments.length, startItemIndex]);
+  }, [comments.length, startItem]);
 
   return (
     <div
@@ -1163,7 +1163,7 @@ scrollTo({
 
 > 💡 It's possible to customize the easing effect of the smoothly scrolling, see the [example](#smooth-scrolling) to learn more.
 
-#### startItemIndex
+#### startItem
 
 `(index: number, callback?: () => void) => void`
 

--- a/src/__tests__/useVirtual.tsx
+++ b/src/__tests__/useVirtual.tsx
@@ -402,10 +402,10 @@ describe("useVirtual", () => {
     });
   });
 
-  it("should `startItemIndex` work correctly", () => {
-    const { startItemIndex, outerRef } = render();
+  it("should `startItem` work correctly", () => {
+    const { startItem, outerRef } = render();
     const cb = jest.fn();
-    startItemIndex(6, cb);
+    startItem(6, cb);
     expect(outerRef.current.scrollTop).toBe(200);
     expect(cb).toHaveBeenCalled();
   });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,7 +98,7 @@ export interface ScrollToItem {
   (index: number | ScrollToItemOptions, callback?: () => void): void;
 }
 
-export interface StartItemIndex {
+export interface StartItem {
   (index: number, callback?: () => void): void;
 }
 
@@ -126,5 +126,5 @@ export interface Return<O = any, I = any> {
   items: Item[];
   scrollTo: ScrollTo;
   scrollToItem: ScrollToItem;
-  startItemIndex: StartItemIndex;
+  startItem: StartItem;
 }

--- a/src/types/react-cool-virtual.d.ts
+++ b/src/types/react-cool-virtual.d.ts
@@ -95,7 +95,7 @@ declare module "react-cool-virtual" {
     (options: ScrollToItemOptions, callback?: Callback): void;
   }
 
-  export interface StartItemIndex {
+  export interface StartItem {
     (index: number, callback?: () => void): void;
   }
 
@@ -126,7 +126,7 @@ declare module "react-cool-virtual" {
     items: Item[];
     scrollTo: ScrollTo;
     scrollToItem: ScrollToItem;
-    startItemIndex: StartItemIndex;
+    startItem: StartItem;
   }
 
   export default function useVirtual<

--- a/src/useVirtual.ts
+++ b/src/useVirtual.ts
@@ -12,7 +12,7 @@ import {
   ScrollToItem,
   ScrollToItemOptions,
   SsrItemCount,
-  StartItemIndex,
+  StartItem,
   State,
 } from "./types";
 import {
@@ -110,7 +110,7 @@ export default <
   }, []);
 
   const measureItems = useCallback(
-    (useCache) => {
+    (useCache = true) => {
       msDataRef.current.length = itemCount;
 
       for (let i = 0; i < itemCount; i += 1)
@@ -232,7 +232,7 @@ export default <
     (
       val: Parameters<ScrollToItem>[0],
       cb: Parameters<ScrollToItem>[1],
-      isReplace?: boolean
+      isSync?: boolean
     ) => {
       const {
         index,
@@ -245,7 +245,7 @@ export default <
       isScrollToItemRef.current = true;
 
       // For dynamic size, we must measure it for getting the correct scroll position
-      if (hasDynamicSizeRef.current) measureItems(!isReplace);
+      if (hasDynamicSizeRef.current) measureItems();
 
       const { current: msData } = msDataRef;
       const ms = msData[Math.max(0, Math.min(index, msData.length - 1))];
@@ -263,7 +263,7 @@ export default <
       }
 
       if (
-        isReplace ||
+        isSync ||
         align === Align.start ||
         (align === Align.auto &&
           scrollOffset + outerSize > end &&
@@ -292,8 +292,10 @@ export default <
       }
 
       scrollToOffset({ offset: scrollOffset, smooth }, () => {
-        if (isReplace || !hasDynamicSizeRef.current) {
+        if (!hasDynamicSizeRef.current) {
           if (cb) cb();
+        } else if (isSync) {
+          requestAnimationFrame(() => scrollToIndex(val, cb, isSync));
         } else {
           setTimeout(() => scrollToIndex(val, cb));
         }
@@ -307,7 +309,7 @@ export default <
     [scrollToIndex]
   );
 
-  const startItemIndex = useCallback<StartItemIndex>(
+  const startItem = useCallback<StartItem>(
     (idx, cb) => scrollToIndex(idx, cb, true),
     [scrollToIndex]
   );
@@ -577,6 +579,6 @@ export default <
     items: state.items,
     scrollTo: scrollToOffset,
     scrollToItem,
-    startItemIndex,
+    startItem,
   };
 };


### PR DESCRIPTION
- Feat: use `startItem` instead `startItemIndex` for pre-pending items (#361)